### PR TITLE
theme 도입 + 리뷰 아이디 기반 동적 라우팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "^10.17.9",
     "iconoir-react": "^7.3.0",
     "next": "14.0.4",
+    "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",

--- a/src/components/review_details/CommentCard.tsx
+++ b/src/components/review_details/CommentCard.tsx
@@ -44,7 +44,7 @@ const CommentCard = ({ comment }: Props) => {
         <div className='flex gap-4'>
           <div className='flex flex-col'>
             <Avatar src='comment.users.avatar_url' showFallback />
-            <p className='text-md'>{comment.users.username}</p>
+            <p className='text-md'>{comment.users.user_name}</p>
           </div>
           <Divider orientation='vertical' className='border-gray-800' />
           <div className='w-full flex justify-between'>

--- a/src/components/review_details/CommentCard.tsx
+++ b/src/components/review_details/CommentCard.tsx
@@ -43,7 +43,7 @@ const CommentCard = ({ comment }: Props) => {
       <CardBody>
         <div className='flex gap-4'>
           <div className='flex flex-col'>
-            <Avatar src='comment.users.avatar_url' showFallback />
+            <Avatar src={comment.users.avatar_url} showFallback />
             <p className='text-md'>{comment.users.user_name}</p>
           </div>
           <Divider orientation='vertical' className='border-gray-800' />

--- a/src/components/review_details/CommentInput.tsx
+++ b/src/components/review_details/CommentInput.tsx
@@ -20,8 +20,8 @@ const CommentInput = ({ reviewId }: Props) => {
     formState: { errors },
   } = useForm({ mode: 'onSubmit' });
   const { isLoggedIn, userId } = useSelector((state: RootState) => state.auth);
-  console.log('로그인됨?>>', isLoggedIn, 'uid >>', userId);
-  console.log('리액트훅폼 에러>>', errors);
+  // console.log('로그인됨?>>', isLoggedIn, 'uid >>', userId);
+  // console.log('리액트훅폼 에러>>', errors);
 
   const [comment, setComment] = useState('');
 
@@ -94,7 +94,7 @@ const CommentInput = ({ reviewId }: Props) => {
           color='primary'
           variant='ghost'
           type='submit'
-          className='w-[100px] h-[60px]'
+          className='w-[100px] h-[60px] '
         >
           등록
         </Button>

--- a/src/components/review_details/CommentList.tsx
+++ b/src/components/review_details/CommentList.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getAllComments } from '@/apis/comments';
 import CommentCard from './CommentCard';
-import { Tables } from '@/types/supabase';
 
 interface Props {
   reviewId: string;
@@ -10,7 +9,7 @@ interface Props {
 
 const CommentList = ({ reviewId }: Props) => {
   const { data: comments, isLoading } = useQuery({
-    queryKey: ['comments'],
+    queryKey: ['comments', reviewId],
     queryFn: () => getAllComments(reviewId),
   });
   console.log('comments', comments);

--- a/src/components/review_details/ReviewBody.tsx
+++ b/src/components/review_details/ReviewBody.tsx
@@ -65,6 +65,7 @@ const ReviewBody = ({ review }: Props) => {
 
   return (
     <>
+      <p className='bg-secondary'>theme testing</p>
       {!isEditing && <NoSsrViewer content={content} />}
       {isEditing && (
         <form onSubmit={editDoneButtonHandler}>

--- a/src/components/review_details/ReviewBody.tsx
+++ b/src/components/review_details/ReviewBody.tsx
@@ -65,7 +65,6 @@ const ReviewBody = ({ review }: Props) => {
 
   return (
     <>
-      <p className='bg-secondary'>theme testing</p>
       {!isEditing && <NoSsrViewer content={content} />}
       {isEditing && (
         <form onSubmit={editDoneButtonHandler}>
@@ -74,6 +73,7 @@ const ReviewBody = ({ review }: Props) => {
         </form>
       )}
       <Button
+        color='primary'
         onClick={() => {
           setIsEditing((prev) => !prev);
         }}

--- a/src/pages/place/[placeId]/index.tsx
+++ b/src/pages/place/[placeId]/index.tsx
@@ -61,7 +61,7 @@ const PlacePage = () => {
       {/* 리뷰 */}
       <section>
         <h2 className='mb-[50px] text-3xl font-bold text-center'>방문 후기</h2>
-        <div className='flex gap-6 px-6 mb-[20px]'>
+        <div className='flex gap-6 px-6 mb-[20px] flex-wrap justify-center items-center'>
           {/* 리뷰카드 */}
           {reviews?.map((review) => (
             <Link href={`/review/${review.id}`} key={review.id}>

--- a/src/pages/providers.tsx
+++ b/src/pages/providers.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import { NextUIProvider } from '@nextui-org/react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import store from '@/redux/config/configStore';
 import { Provider } from 'react-redux';
 import { ToastContainer } from 'react-toastify';
@@ -31,11 +32,18 @@ const Providers = ({ children }: Props) => {
   return (
     <QueryClientProvider client={queryClient}>
       <NextUIProvider>
-        <Provider store={store}>
-          {children}
-          <ReactQueryDevtools initialIsOpen={false} />
-          <ToastContainer />
-        </Provider>
+        <NextThemesProvider
+          attribute='class'
+          defaultTheme='baple'
+          //TODO: light, dark 대신 low-vision 이나 high-contrast 같은 theme 만들기
+          themes={['light', 'dark', 'baple']}
+        >
+          <Provider store={store}>
+            {children}
+            <ReactQueryDevtools initialIsOpen={false} />
+            <ToastContainer />
+          </Provider>
+        </NextThemesProvider>
       </NextUIProvider>
     </QueryClientProvider>
   );

--- a/src/pages/review/[reviewId]/index.tsx
+++ b/src/pages/review/[reviewId]/index.tsx
@@ -9,15 +9,19 @@ import { REVIEW_ID } from '@/constants/temp_develop';
 import { getReviewById } from '@/apis/reviews';
 import { Spacer } from '@nextui-org/react';
 import Seo from '@/components/layout/Seo';
+import { useRouter } from 'next/router';
 
 const ReviewPage = () => {
+  const router = useRouter();
+  const reviewId = router.query.reviewId as string;
+
   const {
     data: review,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['review', REVIEW_ID],
-    queryFn: () => getReviewById(REVIEW_ID),
+    queryKey: ['review', reviewId],
+    queryFn: () => getReviewById(reviewId),
   });
 
   if (isLoading) {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -37,6 +37,6 @@ export interface ReviewUpdateParams {
 export interface CommentsWithUser extends Tables<'comments'> {
   users: {
     avatar_url: string;
-    username: string;
+    user_name: string;
   };
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,27 @@
 import { nextui } from '@nextui-org/react';
 import type { Config } from 'tailwindcss';
 
-const config: Config = {
+// const config: Config = {
+//   content: [
+//     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+//     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+//     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+//     './node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}',
+//   ],
+//   theme: {
+//     extend: {
+//       backgroundImage: {
+//         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+//         'gradient-conic':
+//           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+//       },
+//     },
+//   },
+//   plugins: [nextui()],
+//   safelist: ['h-[200px]', 'h-[300px]'],
+// };
+
+module.exports = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -17,7 +37,55 @@ const config: Config = {
       },
     },
   },
-  plugins: [nextui()],
+  darkMode: 'class',
+  plugins: [
+    nextui({
+      themes: {
+        light: {
+          layout: {},
+          colors: {},
+        },
+        dark: {
+          layout: {},
+          colors: {},
+        },
+        baple: {
+          extend: 'light',
+          colors: {
+            // background: '#white',
+            foreground: 'black',
+            primary: {
+              100: '#FFE074',
+              500: '#FFD029',
+              900: '#FFB629',
+              DEFAULT: '#FFD029',
+              foreground: '#1E1E1E',
+            },
+            secondary: {
+              DEFAULT: '#FF518F',
+              foreground: 'black',
+            },
+
+            focus: '#FFB629',
+          },
+          layout: {
+            disabledOpacity: '0.3',
+            radius: {
+              small: '4px',
+              medium: '6px',
+              large: '8px',
+            },
+            borderWidth: {
+              small: '1px',
+              medium: '2px',
+              large: '3px',
+            },
+          },
+        },
+      },
+    }),
+  ],
   safelist: ['h-[200px]', 'h-[300px]'],
 };
-export default config;
+
+// export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -52,7 +52,7 @@ module.exports = {
         baple: {
           extend: 'light',
           colors: {
-            // background: '#white',
+            background: '#white',
             foreground: 'black',
             primary: {
               100: '#FFE074',
@@ -61,6 +61,7 @@ module.exports = {
               DEFAULT: '#FFD029',
               foreground: '#1E1E1E',
             },
+
             secondary: {
               DEFAULT: '#FF518F',
               foreground: 'black',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3743,6 +3743,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+next-themes@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.2.1.tgz#0c9f128e847979daf6c67f70b38e6b6567856e45"
+  integrity sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==
+
 next@14.0.4:
   version "14.0.4"
   resolved "https://registry.yarnpkg.com/next/-/next-14.0.4.tgz#bf00b6f835b20d10a5057838fa2dfced1d0d84dc"


### PR DESCRIPTION
## 변경사항
 * 웹 어플리케이션 전체에 적용할 수 있는 theme 생성
 * 현재 default theme 은 baple
 * 추후 저시력theme 이나 고대비 theme 추가 예정
 * 장소 상세 페이지에서 하단의 리뷰 카드를 누르면 해당 리뷰로 연결되도록 라우팅.
 

## theme 사용법
1. pull 받은 이후부터는 자동으로 색을 primary 로 했을 경우 디자이너님과 사전 협의된 노란 색으로 표시됨
2. secondary 에는 디자이너님과 사전 협의된 핑크 색이 들어감
3. nextUI 컴포넌트 뿐만 아니라 tailwindCSS를 쓰는 모든 태그에 다 사용가능함
4. nextUI 컴포넌트에선 color 속성의 value 를 적으면 되고 일반적인 컴포넌트에선 className 에서 사용가능함
일반적인 html 요소 예시: `<p className='bg-primary'>theme test</p> `
nextUI 예시 : `<Button
          color='primary'
          variant='ghost'
          type='submit'
          className='w-[100px] h-[60px] '
        >
          등록
        </Button>`
5. theme 설정 변경 `tailwind.config.ts` 에서 baple 객체를 설정하면 됨.
