### PR TITLE
[feat/review_update] 리뷰 수정창에서 에디터 제거-> textarea 로 대체 (#52)

### DIFF
--- a/src/components/review_details/ReviewBody.tsx
+++ b/src/components/review_details/ReviewBody.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Button, Spacer } from '@nextui-org/react';
-import dynamic from 'next/dynamic';
 import { updateReviewContent } from '@/apis/reviews';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -10,18 +9,15 @@ interface Props {
   review: Tables<'reviews'>;
 }
 
-const NoSsrEditor = dynamic(() => import('../common/TuiEditor'), {
-  ssr: false,
-});
-const NoSsrViewer = dynamic(() => import('../common/TuiViewer'), {
-  ssr: false,
-});
-
 const ReviewBody = ({ review }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
   const { id, created_at, content, user_id, place_id } = review;
+  const [editValue, setEditValue] = useState(content);
+
+  console.log('content', content);
 
   const queryClient = useQueryClient();
+
   const updateReviewMutate = useMutation({
     mutationFn: updateReviewContent,
     onMutate: async (updateReviewParams) => {
@@ -50,25 +46,31 @@ const ReviewBody = ({ review }: Props) => {
     },
   });
 
-  const ref = useRef<any>(null);
-
   const editDoneButtonHandler = async (e: React.FormEvent) => {
     e.preventDefault();
-    try {
-      const editorIns = ref?.current?.getInstance();
-      const editValue = editorIns.getMarkdown();
-      updateReviewMutate.mutate({ id, editValue });
-    } catch {
-      console.error('알수 없는 오류 발생');
-    }
+
+    updateReviewMutate.mutate({ id, editValue });
   };
 
   return (
     <>
-      {!isEditing && <NoSsrViewer content={content} />}
+      {!isEditing && (
+        <textarea
+          className='w-[1000px] h-[500px] text-black bg-white'
+          value={content}
+          disabled
+        />
+      )}
       {isEditing && (
         <form onSubmit={editDoneButtonHandler}>
-          <NoSsrEditor content={content} editorRef={ref} />
+          <textarea
+            className='w-[1000px] h-[500px] text-black'
+            onChange={(e) => {
+              console.log(e.target.value);
+              setEditValue(e.target.value);
+            }}
+            value={editValue}
+          />
           <Button type='submit'>수정완료</Button>
         </form>
       )}

--- a/src/components/review_details/ReviewBody.tsx
+++ b/src/components/review_details/ReviewBody.tsx
@@ -74,6 +74,7 @@ const ReviewBody = ({ review }: Props) => {
           <Button type='submit'>수정완료</Button>
         </form>
       )}
+      <Spacer y={5} />
       <Button
         color='primary'
         onClick={() => {

--- a/src/components/review_details/ReviewBody.tsx
+++ b/src/components/review_details/ReviewBody.tsx
@@ -4,13 +4,15 @@ import { updateReviewContent } from '@/apis/reviews';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { Tables } from '@/types/supabase';
+import { toastSuccess } from '@/libs/toastifyAlert';
 
 interface Props {
   review: Tables<'reviews'>;
+  isEditing: boolean;
+  setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const ReviewBody = ({ review }: Props) => {
-  const [isEditing, setIsEditing] = useState(false);
+const ReviewBody = ({ review, isEditing, setIsEditing }: Props) => {
   const { id, created_at, content, user_id, place_id } = review;
   const [editValue, setEditValue] = useState(content);
 
@@ -50,42 +52,41 @@ const ReviewBody = ({ review }: Props) => {
     e.preventDefault();
 
     updateReviewMutate.mutate({ id, editValue });
+
+    toastSuccess('수정 완료되었습니다');
   };
 
   return (
     <>
       {!isEditing && (
         <textarea
-          className='w-[1000px] h-[500px] text-black bg-white'
+          className='w-full h-[300px] text-black bg-white resize-none'
           value={content}
           disabled
+          draggable={false}
         />
       )}
       {isEditing && (
         <form onSubmit={editDoneButtonHandler}>
-          <textarea
-            className='w-[1000px] h-[500px] text-black'
-            onChange={(e) => {
-              console.log(e.target.value);
-              setEditValue(e.target.value);
-            }}
-            value={editValue}
-          />
-          <Button type='submit'>수정완료</Button>
+          <div className='flex flex-col items-center'>
+            <textarea
+              className='w-full h-[300px] text-black resize-none'
+              onChange={(e) => {
+                console.log(e.target.value);
+                setEditValue(e.target.value);
+              }}
+              value={editValue}
+              draggable={false}
+            />
+            <Spacer y={3} />
+            <Button color='primary' type='submit'>
+              수정완료
+            </Button>
+          </div>
         </form>
       )}
-      <Spacer y={5} />
-      <Button
-        color='primary'
-        onClick={() => {
-          setIsEditing((prev) => !prev);
-        }}
-      >
-        수정state토글
-      </Button>
+
       <Spacer y={10} />
-      <p>placeid:{place_id}</p>
-      <p>userid:{user_id}</p>
     </>
   );
 };

--- a/src/components/review_details/ReviewUpperSection.tsx
+++ b/src/components/review_details/ReviewUpperSection.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteReview } from '@/apis/reviews';
 import { toastError, toastSuccess } from '@/libs/toastifyAlert';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 interface Props {
   review: ReviewWithPlaceAndUser;
@@ -35,7 +36,9 @@ const ReviewUpperSection = ({ review }: Props) => {
   return (
     <>
       <Spacer y={10} />
-      <strong className='text-2xl'>{review.places.place_name}</strong>
+      <Link href={`/place/${review.place_id}`}>
+        <strong className='text-2xl'>{review.places.place_name}</strong>
+      </Link>
       <Spacer y={5} />
 
       <div className='flex justify-between items-center gap-4'>

--- a/src/components/review_details/ReviewUpperSection.tsx
+++ b/src/components/review_details/ReviewUpperSection.tsx
@@ -10,9 +10,11 @@ import Link from 'next/link';
 
 interface Props {
   review: ReviewWithPlaceAndUser;
+  isEditing: boolean;
+  setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const ReviewUpperSection = ({ review }: Props) => {
+const ReviewUpperSection = ({ review, setIsEditing, isEditing }: Props) => {
   const queryClient = useQueryClient();
   const router = useRouter();
 
@@ -54,8 +56,14 @@ const ReviewUpperSection = ({ review }: Props) => {
           <Button size='sm' color='primary' onClick={reviewDelete}>
             삭제
           </Button>
-          <Button size='sm' color='primary'>
-            수정
+          <Button
+            size='sm'
+            color='primary'
+            onClick={() => {
+              setIsEditing((prev) => !prev);
+            }}
+          >
+            {isEditing ? '취소' : '수정'}
           </Button>
         </div>
       </div>

--- a/src/pages/review/[reviewId]/index.tsx
+++ b/src/pages/review/[reviewId]/index.tsx
@@ -4,7 +4,7 @@ import CommentInput from '@/components/review_details/CommentInput';
 import CommentList from '@/components/review_details/CommentList';
 import ReviewBody from '@/components/review_details/ReviewBody';
 import { useQuery } from '@tanstack/react-query';
-import React from 'react';
+import React, { useState } from 'react';
 import { getReviewById } from '@/apis/reviews';
 import { Avatar, Button, Spacer } from '@nextui-org/react';
 import Seo from '@/components/layout/Seo';
@@ -15,6 +15,7 @@ import ReviewUpperSection from '@/components/review_details/ReviewUpperSection';
 const ReviewPage = () => {
   const router = useRouter();
   const reviewId = router.query.reviewId as string;
+  const [isEditing, setIsEditing] = useState(false);
 
   const {
     data: review,
@@ -39,7 +40,11 @@ const ReviewPage = () => {
     return (
       <>
         <MainWrapper>
-          <ReviewUpperSection review={review} />
+          <ReviewUpperSection
+            review={review}
+            setIsEditing={setIsEditing}
+            isEditing={isEditing}
+          />
 
           <Seo title='Review' />
           <ReviewLikes review={review} />
@@ -51,7 +56,11 @@ const ReviewPage = () => {
             />
           )}
           <Spacer y={10} />
-          <ReviewBody review={review} />
+          <ReviewBody
+            review={review}
+            isEditing={isEditing}
+            setIsEditing={setIsEditing}
+          />
           <Spacer y={10} />
           <CommentInput reviewId={review.id} />
           <Spacer y={10} />


### PR DESCRIPTION
 - 기존 에디터 textarea로 대체
 - 리뷰 상세의 상단에 있는 장소 이름을 클릭하면 해당 장소 페이지로 이동. <Link>사용
 - 수정 도중 취소할 수 있는 버튼 생성
 - 수정 완료 버튼 위치 및 색 조절
![image](https://github.com/hyewon-han/baple/assets/49670820/965065a6-3481-4ce0-afe0-7d89c5f7bcd6)
