### PR TITLE
[fix/review] 디버깅 + 리팩토링 + 스타일링 (#95)

### DIFF
--- a/src/components/home/MostBookmarks.tsx
+++ b/src/components/home/MostBookmarks.tsx
@@ -9,12 +9,18 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/effect-fade';
 import { Spacer } from '@nextui-org/react';
+import { PlacesForPlaceCard } from '@/types/types';
 
-const MostBookmarks = () => {
+interface Props {
+  initialData: PlacesForPlaceCard[];
+}
+
+const MostBookmarks = ({ initialData }: Props) => {
   const { data: topBookmarkedPlacesList, isLoading: placesListLoading } =
     useQuery({
       queryKey: ['topBookmarkedPlacesList'],
       queryFn: getTopBookmarkedPlaces,
+      initialData: initialData,
     });
 
   if (placesListLoading) {

--- a/src/components/home/MostReviews.tsx
+++ b/src/components/home/MostReviews.tsx
@@ -9,12 +9,18 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/effect-fade';
 import { Spacer } from '@nextui-org/react';
+import { PlacesForPlaceCard } from '@/types/types';
 
-const MostReviews = () => {
+interface Props {
+  initialData: PlacesForPlaceCard[];
+}
+
+const MostReviews = ({ initialData }: Props) => {
   const { data: topReviewedPlacesList, isLoading: placesListLoading } =
     useQuery({
       queryKey: ['topReviewedPlacesList'],
       queryFn: getTopReviewedPlaces,
+      initialData: initialData,
     });
 
   if (placesListLoading) {

--- a/src/components/review_details/ReviewBody.tsx
+++ b/src/components/review_details/ReviewBody.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
 import { Button, Spacer } from '@nextui-org/react';
-import { updateReviewContent } from '@/apis/reviews';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { Tables } from '@/types/supabase';
 import { toastSuccess } from '@/libs/toastifyAlert';
+import { useReviews } from '@/hooks/useReviews';
 
 interface Props {
   review: Tables<'reviews'>;
@@ -16,40 +15,12 @@ const ReviewBody = ({ review, isEditing, setIsEditing }: Props) => {
   const { id, created_at, content, user_id, place_id } = review;
   const [editValue, setEditValue] = useState(content);
 
-  const queryClient = useQueryClient();
-
-  const updateReviewMutate = useMutation({
-    mutationFn: updateReviewContent,
-    onMutate: async (updateReviewParams) => {
-      await queryClient.cancelQueries({ queryKey: ['review', id] });
-      const prevReview: object | undefined = queryClient.getQueryData([
-        'review',
-        id,
-      ]);
-      const updatedReview = {
-        ...prevReview,
-        content: updateReviewParams.editValue,
-      };
-      queryClient.setQueryData(['review', id], updatedReview);
-
-      return { prevReview };
-    },
-    onError: (error, updateReviewParams, context) => {
-      // Rollback to the previous review data in case of an error
-      if (context?.prevReview) {
-        queryClient.setQueryData(['review', id], context.prevReview);
-      }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['review', id] });
-      setIsEditing(false);
-    },
-  });
+  const { updateReview } = useReviews(setIsEditing, place_id, undefined, id);
 
   const editDoneButtonHandler = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    updateReviewMutate.mutate({ id, editValue });
+    updateReview({ id, editValue });
 
     toastSuccess('수정 완료되었습니다');
   };

--- a/src/components/review_details/ReviewUpperSection.tsx
+++ b/src/components/review_details/ReviewUpperSection.tsx
@@ -1,12 +1,11 @@
 import { Avatar, Button, Divider, Spacer } from '@nextui-org/react';
 import React from 'react';
 import type { ReviewWithPlaceAndUser } from '@/types/types';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { deleteReview } from '@/apis/reviews';
-import { toastError, toastSuccess } from '@/libs/toastifyAlert';
+import { toastSuccess } from '@/libs/toastifyAlert';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Swal from 'sweetalert2';
+import { useReviews } from '@/hooks/useReviews';
 
 interface Props {
   review: ReviewWithPlaceAndUser;
@@ -21,26 +20,16 @@ const ReviewUpperSection = ({
   isEditing,
   currentUserId,
 }: Props) => {
-  const queryClient = useQueryClient();
   const router = useRouter();
 
   const showDelEditBtn = currentUserId === review.user_id ? true : false;
 
-  const reviewDelteMutate = useMutation({
-    mutationFn: deleteReview,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['reviews', review.place_id],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['reviews', currentUserId],
-      });
-    },
-    onError: () => {
-      toastError('문제가 발생하여 삭제하지 못했습니다');
-      return;
-    },
-  });
+  const { deleteReview } = useReviews(
+    undefined,
+    review.place_id,
+    currentUserId as string,
+  );
+
   const reviewDelete = () => {
     Swal.fire({
       icon: 'warning',
@@ -51,7 +40,7 @@ const ReviewUpperSection = ({
       confirmButtonColor: '#FFD029',
     }).then((result) => {
       if (result.isConfirmed) {
-        reviewDelteMutate.mutate(review.id);
+        deleteReview(review.id);
         router.back();
         toastSuccess('삭제 완료');
       }

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -1,0 +1,83 @@
+import {
+  deleteReview,
+  insertNewReview,
+  updateReviewContent,
+} from '@/apis/reviews';
+import { toastError } from '@/libs/toastifyAlert';
+import {
+  useMutation,
+  useQueryClient,
+  InvalidateQueryFilters,
+} from '@tanstack/react-query';
+
+export const useReviews = (
+  setIsEditing?: React.Dispatch<React.SetStateAction<boolean>>,
+  placeId?: string,
+  currentUserId?: string,
+  reviewId?: string,
+) => {
+  const queryClient = useQueryClient();
+
+  const reviewDelteMutate = useMutation({
+    mutationFn: deleteReview,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['reviews', placeId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['reviews', currentUserId],
+      });
+    },
+    onError: () => {
+      toastError('문제가 발생하여 삭제하지 못했습니다');
+      return;
+    },
+  });
+
+  const updateReviewMutate = useMutation({
+    mutationFn: updateReviewContent,
+    onMutate: async (updateReviewParams) => {
+      await queryClient.cancelQueries({ queryKey: ['review', reviewId] });
+      const prevReview: object | undefined = queryClient.getQueryData([
+        'review',
+        reviewId,
+      ]);
+      const updatedReview = {
+        ...prevReview,
+        content: updateReviewParams.editValue,
+      };
+      queryClient.setQueryData(['review', reviewId], updatedReview);
+
+      return { prevReview };
+    },
+    onError: (error, updateReviewParams, context) => {
+      // Rollback to the previous review data in case of an error
+      if (context?.prevReview) {
+        queryClient.setQueryData(['review', reviewId], context.prevReview);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['review', reviewId] });
+      queryClient.invalidateQueries({ queryKey: ['reviews', placeId] });
+      if (setIsEditing) {
+        setIsEditing(false);
+      }
+    },
+  });
+
+  const insertReviewMutate = useMutation({
+    mutationFn: insertNewReview,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries([
+        'reviews',
+        placeId,
+      ] as InvalidateQueryFilters);
+    },
+  });
+
+  return {
+    deleteReview: reviewDelteMutate.mutate,
+    updateReview: updateReviewMutate.mutate,
+    insertReview: insertReviewMutate.mutate,
+  };
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,8 @@ import MostReviews from '@/components/home/MostReviews';
 import MostBookmarks from '@/components/home/MostBookmarks';
 import { Spacer } from '@nextui-org/react';
 import Carousel from '@/components/common/Carousel';
+import { getTopBookmarkedPlaces, getTopReviewedPlaces } from '@/apis/places';
+import { PlacesForPlaceCard } from '@/types/types';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -16,7 +18,12 @@ const imgList = [
   'https://dummyimage.com/1200x400/f0c518/000000&text=BAPLE',
 ];
 
-const Home = () => {
+interface Props {
+  topBookmarked: PlacesForPlaceCard[];
+  topReviewed: PlacesForPlaceCard[];
+}
+
+const Home = ({ topBookmarked, topReviewed }: Props) => {
   const { username, userId } = useSelector((state: RootState) => state.auth);
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -38,9 +45,9 @@ const Home = () => {
         />
       </section>
       <div className='flex flex-col w-full justify-center items-center'>
-        <MostReviews />
+        <MostReviews initialData={topReviewed} />
         <Spacer y={10} />
-        <MostBookmarks />
+        <MostBookmarks initialData={topBookmarked} />
         <Spacer y={20} />
       </div>
     </>
@@ -48,3 +55,9 @@ const Home = () => {
 };
 
 export default Home;
+
+export async function getServerSideProps() {
+  const topBookmarked = await getTopBookmarkedPlaces();
+  const topReviewed = await getTopReviewedPlaces();
+  return { props: { topBookmarked, topReviewed } };
+}

--- a/src/pages/places/index.tsx
+++ b/src/pages/places/index.tsx
@@ -1,7 +1,9 @@
+import PlaceCard from '@/components/common/PlaceCard';
 import PlaceCard2 from '@/components/common/PlaceCard2';
 import MainWrapper from '@/components/layout/MainWrapper';
 import { supabase } from '@/libs/supabase';
 import { Tables } from '@/types/supabase';
+import { PlacesForSearch } from '@/types/types';
 import { Button, Input, Spacer } from '@nextui-org/react';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
@@ -11,7 +13,7 @@ const PlacesPage = () => {
   const [selected, setSelected] = useState<string[]>([]);
   const [checkboxChanged, setCheckboxChanged] = useState(false);
   const [searchValue, setSearchValue] = useState('');
-  const [searchedPlaces, setSearchedPlaces] = useState<Tables<'places'>[]>([]);
+  const [searchedPlaces, setSearchedPlaces] = useState<PlacesForSearch[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [loading, setLoading] = useState(false);
   const queryClient = useQueryClient();
@@ -43,10 +45,9 @@ const PlacesPage = () => {
     setLoading(true);
 
     try {
-      let query = supabase
-        .from('places')
-        .select('*')
-        .ilike('place_name', `%${searchValue}%`);
+      let query = supabase.rpc('search_places', {
+        p_search_value: searchValue,
+      });
 
       if (selected.length > 0) {
         selected.forEach((checkbox) => {
@@ -138,7 +139,7 @@ const PlacesPage = () => {
           <div className='flex justify-center'>
             <div className='grid lg:grid-cols-3 sm:grid-cols-2 gap-[3rem] w-full'>
               {searchedPlaces.map((place, idx) => (
-                <PlaceCard2 key={idx} place={place} />
+                <PlaceCard key={idx} place={place} />
               ))}
             </div>
           </div>

--- a/src/pages/review/write/[placeId]/index.tsx
+++ b/src/pages/review/write/[placeId]/index.tsx
@@ -8,13 +8,13 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { insertNewReview } from '@/apis/reviews';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { supabase } from '@/libs/supabase';
 import { toastSuccess, toastWarn } from '@/libs/toastifyAlert';
 import { getPlaceInfo, updatePlaceImage } from '@/apis/places';
 import Seo from '@/components/layout/Seo';
+import { useReviews } from '@/hooks/useReviews';
 
 const ReviewWritePage = () => {
   const [reviewText, setReviewText] = useState('');
@@ -64,15 +64,8 @@ const ReviewWritePage = () => {
   console.log('selectedImages', selectedImages);
   console.log('selectedFiles', selectedFiles);
   const queryClient = useQueryClient();
-  const { mutate: mutateToAdd } = useMutation({
-    mutationFn: insertNewReview,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries([
-        'reviews',
-        placeId,
-      ] as InvalidateQueryFilters);
-    },
-  });
+
+  const { insertReview } = useReviews(undefined, placeId as string);
 
   const { mutate: mutateToUpdate } = useMutation({
     mutationFn: updatePlaceImage,
@@ -130,7 +123,7 @@ const ReviewWritePage = () => {
       userId,
       publicUrlList,
     };
-    mutateToAdd(args);
+    insertReview(args);
     toastSuccess('리뷰가 등록되었습니다.');
     // setReviewText('');
     router.replace(`/place/${placeId}`);

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -105,3 +105,13 @@ export interface PlacesForPlaceCard {
   place_name: string;
   unique_place_id: string;
 }
+export interface PlacesForSearch extends PlacesForPlaceCard {
+  is_paid: boolean;
+  is_easy_door: boolean;
+  is_wheelchair_rental: boolean;
+  is_guide_dog: boolean;
+  is_braille_guide: boolean;
+  is_audio_guide: boolean;
+  is_disabled_toilet: boolean;
+  is_disabled_parking: boolean;
+}


### PR DESCRIPTION
 * 메인 페이지에 getServerSideProps 도입
 * reviews 관련 CUD 커스텀 훅으로 처리
 * 장소 검색 페이지에서 rpc 함수 사용
   (검색 기능은 이전과 다름없이 동작하는 것으로 보이나 로컬에서 테스트 바랍니다)

before
  
![스크린샷 2024-01-24 192240](https://github.com/hyewon-han/baple/assets/49670820/ddb52cd2-9377-468a-a1a0-9bed019a2fd9)

after
![스크린샷 2024-01-24 192300](https://github.com/hyewon-han/baple/assets/49670820/f0279839-189e-4a17-9555-95c56af78022)
