### PR TITLE
[feat/main_search] 메인페이지에서 검색 기능 작동시키기(#133)

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { Inter } from 'next/font/google';
 import Seo from '@/components/layout/Seo';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@/redux/config/configStore';
 import { useEffect, useState } from 'react';
 import MostReviews from '@/components/home/MostReviews';
@@ -8,10 +8,12 @@ import MostBookmarks from '@/components/home/MostBookmarks';
 import { Button, Spacer } from '@nextui-org/react';
 import Carousel from '@/components/common/Carousel';
 import { getTopBookmarkedPlaces, getTopReviewedPlaces } from '@/apis/places';
-import { PlacesForPlaceCard, PlacesForSearch } from '@/types/types';
+import { PlacesForSearch } from '@/types/types';
 import TopButton from '@/components/common/TopButton';
 import Image from 'next/image';
 import MainWrapper from '@/components/layout/MainWrapper';
+import { setSearchValue } from '@/redux/modules/searchValueSlice';
+import { useRouter } from 'next/navigation';
 
 // const inter = Inter({ subsets: ['latin'] });
 
@@ -33,6 +35,15 @@ const Home = ({ topBookmarked, topReviewed }: Props) => {
   useEffect(() => {
     setIsLoaded(true);
   }, []);
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    dispatch(setSearchValue(localSearchValue));
+    router.push('/places');
+  };
+
+  const [localSearchValue, setLocalSearchValue] = useState('');
   return (
     <div>
       <Seo title='Home' />
@@ -42,19 +53,21 @@ const Home = ({ topBookmarked, topReviewed }: Props) => {
         slideHeight={'400px'} // 캐러셀 높이
       />
       <MainWrapper>
-        <div className='flex justify-center w-full sm:w-[60%] m-auto mt-10 mb-4 sm:mb-8 bg-primary p-[2px] rounded-full overflow-hidden'>
-          {/* 검색창 */}
+        {/* 검색창 */}
+        <form
+          onSubmit={handleSearch}
+          className='flex justify-center w-full sm:w-[60%] m-auto mt-10 mb-4 sm:mb-8 bg-primary p-[2px] rounded-full overflow-hidden'
+        >
           <input
             placeholder='장소이름을 검색하세요'
-            // value={searchValue}
-            // onChange={(e) => setSearchValue(e.target.value)}
+            value={localSearchValue}
+            onChange={(e) => setLocalSearchValue(e.target.value)}
             className='rounded-full w-[80%] sm:w-full p-2 px-4 placeholder:text-md focus:outline-none'
           />
           <Button
             color='primary'
             type='submit'
             className='h-auto w-[20%] rounded-r-full'
-            // onClick={handleClickSearch}
           >
             <Image
               src='/images/icons/search_white.svg'
@@ -63,7 +76,7 @@ const Home = ({ topBookmarked, topReviewed }: Props) => {
               alt='search_icon'
             />
           </Button>
-        </div>
+        </form>
         <div className='flex flex-col w-full justify-center items-center'>
           <MostReviews initialData={topReviewed} />
           <Spacer y={10} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import TopButton from '@/components/common/TopButton';
 import Image from 'next/image';
 import MainWrapper from '@/components/layout/MainWrapper';
 import { setSearchValue } from '@/redux/modules/searchValueSlice';
-import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/router';
 
 // const inter = Inter({ subsets: ['latin'] });
 

--- a/src/pages/places/index.tsx
+++ b/src/pages/places/index.tsx
@@ -3,6 +3,8 @@ import PlaceCard2 from '@/components/common/PlaceCard2';
 import TopButton from '@/components/common/TopButton';
 import MainWrapper from '@/components/layout/MainWrapper';
 import { supabase } from '@/libs/supabase';
+import { RootState } from '@/redux/config/configStore';
+import { setSearchValue } from '@/redux/modules/searchValueSlice';
 import { Tables } from '@/types/supabase';
 import { PlacesForSearch } from '@/types/types';
 import { Button, Input, Spacer } from '@nextui-org/react';
@@ -10,15 +12,19 @@ import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { useDispatch, useSelector } from 'react-redux';
 
 const PlacesPage = () => {
   const [selected, setSelected] = useState<string[]>([]);
   const [checkboxChanged, setCheckboxChanged] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
+  // const [searchValue, setSearchValue] = useState('');
   const [searchedPlaces, setSearchedPlaces] = useState<PlacesForSearch[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [loading, setLoading] = useState(false);
   const pageSize = 20;
+
+  const searchValue = useSelector((state: RootState) => state.searchValue);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     handleSearch();
@@ -30,6 +36,13 @@ const PlacesPage = () => {
       setCheckboxChanged(false);
     }
   }, [checkboxChanged, selected]);
+
+  useEffect(() => {
+    //클린업함수 -> 언마운트 될때 redux state 빈 스트링으로 초기화
+    return () => {
+      dispatch(setSearchValue(''));
+    };
+  }, [dispatch]);
 
   const handleSearch = () => {
     setSearchedPlaces([]);
@@ -110,7 +123,7 @@ const PlacesPage = () => {
         <input
           placeholder='장소이름을 검색하세요'
           value={searchValue}
-          onChange={(e) => setSearchValue(e.target.value)}
+          onChange={(e) => dispatch(setSearchValue(e.target.value))}
           className='rounded-full w-[80%] sm:w-full p-2 px-4 placeholder:text-md focus:outline-none'
         />
         <Button

--- a/src/redux/config/configStore.ts
+++ b/src/redux/config/configStore.ts
@@ -1,10 +1,11 @@
 import auth from '../../redux/modules/authSlice';
 import { configureStore } from '@reduxjs/toolkit';
 import placesData from '../modules/placesDataSlice';
+import searchValue from '../modules/searchValueSlice';
 
 export type RootState = ReturnType<typeof store.getState>;
 const store = configureStore({
-  reducer: { auth, placesData },
+  reducer: { auth, placesData, searchValue },
 });
 export default store;
 

--- a/src/redux/modules/searchValueSlice.ts
+++ b/src/redux/modules/searchValueSlice.ts
@@ -1,0 +1,16 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = '';
+
+const searchValueSlice = createSlice({
+  name: 'searchValue',
+  initialState,
+  reducers: {
+    setSearchValue: (state, action) => {
+      return (state = action.payload);
+    },
+  },
+});
+
+export default searchValueSlice.reducer;
+export const { setSearchValue } = searchValueSlice.actions;


### PR DESCRIPTION
 * 메인 페이지 검색 기능 places 페이지와 연결
 * 메인 페이지에서 검색하면 자동으로 해당 검색어와 검색 결과를 가지고 places 페이지로 넘어감
 
!! 검색 필터를 설정하는 '순서' 에 따라서 검색 결과가 다르게 나타나는 기괴한 문제 발견.
해당 문제가 새로 발생한 것일 경우 merge 유보. 기존에 존재하던 문제라면 merge. 

![스크린샷 2024-01-27 171433](https://github.com/hyewon-han/baple/assets/49670820/fac04ae3-5a1c-499a-aeee-e64043f0fec0)
![스크린샷 2024-01-27 171441](https://github.com/hyewon-han/baple/assets/49670820/7fa1ca59-1684-4a97-9a43-e438ad456520)

[장애인용 출입문 -> 휠체어 대여 ] 순서로 눌렀을 경우
![스크린샷 2024-01-27 172116](https://github.com/hyewon-han/baple/assets/49670820/ea331d93-6d05-40e6-8b3c-c24e46375cc0)

[휠체어 대여 -> 장애인용 출입문 ] 순서로 눌렀을 경우
![스크린샷 2024-01-27 172124](https://github.com/hyewon-han/baple/assets/49670820/8a9fb32a-d24a-4e36-8ffa-aa42e8c9395c)
