### PR TITLE
[Feat/image compression] 큰 사진이 업로드 되어도 자동으로 1mb 이하로 압축 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query-devtools": "^5.17.9",
     "@toast-ui/react-editor": "^3.2.3",
     "axios": "^1.6.5",
+    "browser-image-compression": "^2.0.2",
     "framer-motion": "^10.17.9",
     "iconoir-react": "^7.3.0",
     "lodash": "^4.17.21",

--- a/src/components/mypage/MyTabs.tsx
+++ b/src/components/mypage/MyTabs.tsx
@@ -12,6 +12,7 @@ import ReviewCardMobile from '../common/ReviewCardMobile';
 import { useViewport } from '@/hooks/useViewport';
 import PlaceCard3 from '../common/PlaceCard3';
 import Image from 'next/image';
+import _ from 'lodash';
 
 const MyTabs = () => {
   const { userId } = useSelector((state: RootState) => state.auth);
@@ -25,12 +26,20 @@ const MyTabs = () => {
   const { data: likedReviews, isLoading: isLikesLoading } = useQuery({
     queryKey: ['likes', userId],
     queryFn: () => getLikedReviews(userId),
+    select: (data) => {
+      const recentOrderLiked = _.orderBy(data, 'created_at', 'desc');
+      return { recentOrderLiked };
+    },
   });
 
   const { data: writtenReviews, isLoading: isWrittenReviewsLoading } = useQuery(
     {
       queryKey: ['reviews', userId],
       queryFn: () => getReviewsByUserIdrpc(userId),
+      select: (data) => {
+        const recentOrderWritten = _.orderBy(data, 'created_at', 'desc');
+        return { recentOrderWritten };
+      },
     },
   );
 
@@ -85,7 +94,7 @@ const MyTabs = () => {
         <Tab key='liked' title='좋아요한 리뷰'>
           <Card>
             <CardBody>
-              {likedReviews?.length === 0 && (
+              {likedReviews?.recentOrderLiked.length === 0 && (
                 <div className='flex flex-col items-center gap-3 justify-center w-full my-5'>
                   <Image
                     src='/images/icons/character.svg'
@@ -100,14 +109,14 @@ const MyTabs = () => {
               )}
               {!isMobile && (
                 <div className='flex flex-col gap-1'>
-                  {likedReviews?.map((review, idx) => (
+                  {likedReviews?.recentOrderLiked.map((review, idx) => (
                     <ReviewCard2 review={review} key={idx} />
                   ))}
                 </div>
               )}
               {isMobile && (
                 <div className='flex flex-col gap-1'>
-                  {likedReviews?.map((review, idx) => (
+                  {likedReviews?.recentOrderLiked.map((review, idx) => (
                     <ReviewCardMobile review={review} key={idx} />
                   ))}
                 </div>
@@ -119,7 +128,7 @@ const MyTabs = () => {
         <Tab key='written' title='작성한 리뷰'>
           <Card>
             <CardBody>
-              {writtenReviews?.length === 0 && (
+              {writtenReviews?.recentOrderWritten.length === 0 && (
                 <div className='flex flex-col items-center gap-3 justify-center w-full my-5'>
                   <Image
                     src='/images/icons/character.svg'
@@ -132,14 +141,14 @@ const MyTabs = () => {
               )}
               {!isMobile && (
                 <div className='flex flex-col gap-1'>
-                  {writtenReviews?.map((review, idx) => (
+                  {writtenReviews?.recentOrderWritten.map((review, idx) => (
                     <ReviewCard2 review={review} key={idx} />
                   ))}
                 </div>
               )}
               {isMobile && (
                 <div className='flex flex-col gap-1'>
-                  {writtenReviews?.map((review, idx) => (
+                  {writtenReviews?.recentOrderWritten.map((review, idx) => (
                     <ReviewCardMobile review={review} key={idx} />
                   ))}
                 </div>

--- a/src/components/mypage/MyTabs.tsx
+++ b/src/components/mypage/MyTabs.tsx
@@ -13,7 +13,6 @@ import { useViewport } from '@/hooks/useViewport';
 import PlaceCard3 from '../common/PlaceCard3';
 import Image from 'next/image';
 import _ from 'lodash';
-import MainWrapper from '../layout/MainWrapper';
 
 const MyTabs = () => {
   const { userId } = useSelector((state: RootState) => state.auth);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,6 +3519,13 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
 browserslist@^4.22.2:
   version "4.22.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
@@ -5949,6 +5956,7 @@ streamsearch@^1.1.0:
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6009,6 +6017,7 @@ string.prototype.trimstart@^1.0.7:
     es-abstract "^1.22.1"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6360,6 +6369,11 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 w3c-keyname@^2.2.0:
   version "2.2.8"


### PR DESCRIPTION
 * browser-image-compression 라이브러리가 추가되었습니다
 * 큰 이미지를 업로드 해도 클라이언트단에서 자동으로 이미지를 1mb 이하로 압축합니다
 * 가로나 세로 크기는 1920 으로 제한합니다
 * 큰 파일을 등록할때 압축하는데 약간의 시간이 소요되는 경우가 있어 로딩 스피너 도입도 고려할만 합니다.
 * mypage 에서 리뷰카드들을 최신순 정렬하도록 했습니다.